### PR TITLE
Western European encode support

### DIFF
--- a/escpos.go
+++ b/escpos.go
@@ -119,6 +119,18 @@ func (e *Escpos) WriteGBK(data string) (int, error) {
 	return e.WriteRaw([]byte(gbk))
 }
 
+// WriteWEU write a string to the printer with Western European encode
+func (e *Escpos) WriteWEU(data string) (int, error) {
+	cd, err := iconv.Open("cp850", "utf-8")
+	if err != nil {
+		beelog.Critical("iconv.Open failed!")
+		return 0, err
+	}
+	defer cd.Close()
+	weu := cd.ConvString(data)
+	return e.WriteRaw([]byte(weu))
+}
+
 // Init printer settings
 // \x1B@ => ESC @  初始化打印机
 func (e *Escpos) Init() {


### PR DESCRIPTION
This PR adds a new function `WriteWEU` in order to convert from `utf-8` to `cp850` ([Western European encoding](https://en.wikipedia.org/wiki/Code_page_850)) which covers French, Spanish, Italian, Portuguese and German char-sets.

Reference: https://qz.io/wiki/Raw-Encoding#escpos-western-european

**Epson TM-T20II printing screenshot**

<img width="711" alt="image" src="https://user-images.githubusercontent.com/1700322/74636645-b5fe1e00-5168-11ea-994c-ee3404536355.png">

**Notes:**

* The first sentence is English and the second one Spanish (in three examples). 
* The last example shows the right encoding for Spanish using `WriteWEU` function. 
